### PR TITLE
Speed up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
 script:
   - mvn --batch-mode test
 
-deploy:
+#deploy:
   # Only deploy on successful merge into master
-  - ([[ ${TRAVIS_BRANCH} == "master" && ${TRAVIS_PULL_REQUEST} == false ]] && mvn --batch-mode deploy -DskipTests)
+#  - ([[ ${TRAVIS_BRANCH} == "master" && ${TRAVIS_PULL_REQUEST} == false ]] && mvn --batch-mode deploy -DskipTests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,21 @@
 language: java
+
 jdk:
  - oraclejdk8
+
+# Run on container-based infrastructure
+sudo: false
+
+cache:
+  directories:
+    - ${HOME}/.m2/repository
+
+install:
+  - mvn --show-version dependency:resolve
+
+script:
+  - mvn --batch-mode test
+
+deploy:
+  # Only deploy on successful merge into master
+  - ([[ ${TRAVIS_BRANCH} == "master" && ${TRAVIS_PULL_REQUEST} == false ]] && mvn --batch-mode deploy -DskipTests)


### PR DESCRIPTION
@thespags 

1. Using container based infrastructure in Travis. They claim this speeds things up
2. Have Travis cache Maven dependencies so we don't have to keep downloading them each time. Doesn't matter too much now since Midas doesn't download that much, but it will matter eventually.